### PR TITLE
Change backslash to forward slash on windows

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -153,7 +153,11 @@ impl Backend {
             Event::Start(Tag::Paragraph),
             Event::Start(Tag::Image {
                 link_type: LinkType::Inline,
-                dest_url: rel_path.to_string_lossy().to_string().into(),
+                dest_url: rel_path
+                    .to_string_lossy()
+                    .to_string()
+                    .replace("\\", "/")
+                    .into(),
                 title: CowStr::Borrowed(""),
                 id: CowStr::Borrowed(""),
             }),


### PR DESCRIPTION
Change backslash to forward slash for windows compatibility

rel_path might be something like d2\1.1.svg which does not work in html