### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.3.6](https://github.com/danieleades/mdbook-d2/compare/v0.3.5...v0.3.6) - 2025-06-30
+
+### Fixed
+
+- *(ci)* update token used by release-plz to allow triggering downstream jobs ([#149](https://github.com/danieleades/mdbook-d2/pull/149))
+
 ## [0.3.5](https://github.com/danieleades/mdbook-d2/compare/v0.3.4...v0.3.5) - 2025-06-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-d2"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-d2"
 description = "D2 diagram generator plugin for MdBook"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Daniel Eades <danieleades@hotmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-d2`: 0.3.5 -> 0.3.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6](https://github.com/danieleades/mdbook-d2/compare/v0.3.5...v0.3.6) - 2025-06-30

### Fixed

- *(ci)* update token used by release-plz to allow triggering downstream jobs ([#149](https://github.com/danieleades/mdbook-d2/pull/149))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).