### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## [0.3.7](https://github.com/danieleades/mdbook-d2/compare/v0.3.6...v0.3.7) - 2025-11-20
+
+### Added
+
+- update to mdbook 0.5 ([#165](https://github.com/danieleades/mdbook-d2/pull/165))
+
+### Other
+
+- *(deps)* bump tempfile from 3.21.0 to 3.22.0 ([#158](https://github.com/danieleades/mdbook-d2/pull/158))
+- *(deps)* bump tempfile from 3.20.0 to 3.21.0 ([#156](https://github.com/danieleades/mdbook-d2/pull/156))
+- *(deps)* bump amannn/action-semantic-pull-request from 5 to 6 ([#155](https://github.com/danieleades/mdbook-d2/pull/155))
+- *(deps)* bump actions/checkout from 4 to 5 ([#154](https://github.com/danieleades/mdbook-d2/pull/154))
+- *(deps)* bump toml from 0.8.23 to 0.9.0 ([#152](https://github.com/danieleades/mdbook-d2/pull/152))
+- *(deps)* bump the patch-updates group with 2 updates ([#151](https://github.com/danieleades/mdbook-d2/pull/151))
+
 ## [0.3.6](https://github.com/danieleades/mdbook-d2/compare/v0.3.5...v0.3.6) - 2025-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-d2"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-d2"
 description = "D2 diagram generator plugin for MdBook"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Daniel Eades <danieleades@hotmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-d2`: 0.3.6 -> 0.3.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/danieleades/mdbook-d2/compare/v0.3.6...v0.3.7) - 2025-11-20

### Added

- update to mdbook 0.5 ([#165](https://github.com/danieleades/mdbook-d2/pull/165))

### Other

- *(deps)* bump tempfile from 3.21.0 to 3.22.0 ([#158](https://github.com/danieleades/mdbook-d2/pull/158))
- *(deps)* bump tempfile from 3.20.0 to 3.21.0 ([#156](https://github.com/danieleades/mdbook-d2/pull/156))
- *(deps)* bump amannn/action-semantic-pull-request from 5 to 6 ([#155](https://github.com/danieleades/mdbook-d2/pull/155))
- *(deps)* bump actions/checkout from 4 to 5 ([#154](https://github.com/danieleades/mdbook-d2/pull/154))
- *(deps)* bump toml from 0.8.23 to 0.9.0 ([#152](https://github.com/danieleades/mdbook-d2/pull/152))
- *(deps)* bump the patch-updates group with 2 updates ([#151](https://github.com/danieleades/mdbook-d2/pull/151))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).