### PR TITLE
fix: fail the build when a d2 diagram fails to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ layout = "dagre"
 # optional. default is 'true'
 inline = true
 
+# whether a diagram that fails to render should fail the whole build.
+# if 'false', render failures are printed to stderr and the offending diagram is
+# omitted, but the build still succeeds.
+# optional. default is 'false'
+fail-on-error = false
+
 # output directory relative to `src/` for generated diagrams.
 # This is ignored if 'inline' is 'true'.
 # optional. default is "d2".

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -23,6 +23,8 @@ pub struct Backend {
     /// Layout engine to use for D2 diagrams
     layout: Option<String>,
     inline: bool,
+    /// Whether a diagram that fails to render should fail the whole build
+    fail_on_error: bool,
     fonts: Option<Fonts>,
     theme_id: Option<String>,
     dark_theme_id: Option<String>,
@@ -81,6 +83,7 @@ impl Backend {
             output_dir: config.output_dir,
             layout: config.layout,
             inline: config.inline,
+            fail_on_error: config.fail_on_error,
             source_dir,
             fonts: config.fonts,
             theme_id: config.theme_id,
@@ -106,6 +109,11 @@ impl Backend {
     /// Returns the relative path to the output directory
     fn output_dir(&self) -> &Path {
         &self.output_dir
+    }
+
+    /// Whether a diagram that fails to render should fail the whole build
+    pub const fn fail_on_error(&self) -> bool {
+        self.fail_on_error
     }
 
     /// Constructs the absolute file path for a diagram

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,14 @@ pub struct Config {
     #[serde(default = "default::inline")]
     pub inline: bool,
 
+    /// Whether a diagram that fails to render should fail the whole build
+    ///
+    /// When 'false' (the default), render failures are printed to stderr and
+    /// the offending diagram is omitted, but the build still succeeds. When
+    /// 'true', any render failure causes the build to exit with an error.
+    #[serde(default)]
+    pub fail_on_error: bool,
+
     /// Custom font path
     ///
     /// Only ttf fonts are valid
@@ -58,6 +66,7 @@ impl Default for Config {
             layout: None,
             output_dir: default::output_dir(),
             inline: default::inline(),
+            fail_on_error: false,
             fonts: None,
             theme_id: None,
             dark_theme_id: None,
@@ -97,12 +106,23 @@ output-dir = "d2-img"
         path: PathBuf::from("/custom/bin/d2"),
         layout: Some(String::from("elk")),
         inline: true,
+        fail_on_error: false,
         output_dir: PathBuf::from("d2-img"),
         fonts: None,
         theme_id: None,
         dark_theme_id:None,
     }
         ; "custom"
+    )]
+    #[test_case(
+        r"
+fail-on-error = true
+"
+    => Config {
+        fail_on_error: true,
+        ..Config::default()
+    }
+        ; "fail-on-error"
     )]
     fn parse(input: &str) -> Config {
         toml::from_str(input).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,54 +33,80 @@ impl Preprocessor for D2 {
     fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book, Error> {
         let backend = Backend::from_context(ctx);
 
+        // Collect every diagram that fails to render rather than bailing on the
+        // first one, so a single build reports all broken diagrams at once.
+        let mut errors: Vec<Error> = Vec::new();
+
         book.for_each_mut(|section| {
             if let BookItem::Chapter(chapter) = section {
-                let events: Vec<_> = process_events(
-                    &backend,
-                    chapter,
-                    Parser::new_ext(&chapter.content, Options::all()),
-                )
-                .collect();
-
-                // Determine the minimum number of backticks needed for code blocks.
-                // Use 3 (the CommonMark default) unless nested code blocks require more.
-                // This preserves the original markdown structure while correctly handling
-                // code blocks that contain other code block examples.
-                // See: https://github.com/danieleades/mdbook-d2/issues/170
-                let code_block_token_count =
-                    calculate_code_block_token_count(events.iter()).unwrap_or(3);
-
-                let options = pulldown_cmark_to_cmark::Options {
-                    code_block_token_count,
-                    ..Default::default()
-                };
-
-                // create a buffer in which we can place the markdown
-                let mut buf = String::with_capacity(chapter.content.len() + 128);
-
-                // convert it back to markdown and replace the original chapter's content
-                cmark_with_options(events.into_iter(), &mut buf, options).unwrap();
-                chapter.content = buf;
+                chapter.content = render_chapter(&backend, chapter, &mut errors);
             }
         });
+
+        if !errors.is_empty() {
+            let details = errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n");
+            return Err(anyhow::anyhow!(
+                "failed to render {} d2 diagram(s):\n{details}",
+                errors.len()
+            ));
+        }
 
         Ok(book)
     }
 }
 
+/// Renders all d2 diagrams in a chapter and returns the rewritten markdown.
+///
+/// Any diagram that fails to render is pushed onto `errors` (and omitted from
+/// the output) so the caller can surface every failure and fail the build.
+fn render_chapter(backend: &Backend, chapter: &Chapter, errors: &mut Vec<Error>) -> String {
+    let events = process_events(
+        backend,
+        chapter,
+        Parser::new_ext(&chapter.content, Options::all()),
+        errors,
+    );
+
+    // Determine the minimum number of backticks needed for code blocks.
+    // Use 3 (the CommonMark default) unless nested code blocks require more.
+    // This preserves the original markdown structure while correctly handling
+    // code blocks that contain other code block examples.
+    // See: https://github.com/danieleades/mdbook-d2/issues/170
+    let code_block_token_count = calculate_code_block_token_count(events.iter()).unwrap_or(3);
+
+    let options = pulldown_cmark_to_cmark::Options {
+        code_block_token_count,
+        ..Default::default()
+    };
+
+    // create a buffer in which we can place the markdown
+    let mut buf = String::with_capacity(chapter.content.len() + 128);
+
+    // convert it back to markdown
+    cmark_with_options(events.into_iter(), &mut buf, options).unwrap();
+
+    buf
+}
+
 fn process_events<'a>(
-    backend: &'a Backend,
-    chapter: &'a Chapter,
-    events: impl Iterator<Item = Event<'a>> + 'a,
-) -> impl Iterator<Item = Event<'a>> + 'a {
+    backend: &Backend,
+    chapter: &Chapter,
+    events: impl Iterator<Item = Event<'a>>,
+    errors: &mut Vec<Error>,
+) -> Vec<Event<'a>> {
     let mut in_block = false;
     // if Windows crlf line endings are used, a code block will consist
     // of many different Text blocks, thus we need to buffer them in here
     // see https://github.com/raphlinus/pulldown-cmark/issues/507
     let mut diagram = String::new();
     let mut diagram_index = 0;
+    let mut out = Vec::new();
 
-    events.flat_map(move |event| {
+    for event in events {
         match (&event, in_block) {
             // check if we are entering a d2 codeblock
             (
@@ -90,12 +116,10 @@ fn process_events<'a>(
                 in_block = true;
                 diagram.clear();
                 diagram_index += 1;
-                vec![]
             }
             // check if we are currently inside a d2 block
             (Event::Text(content), true) => {
                 diagram.push_str(content);
-                vec![]
             }
             // check if we are exiting a d2 block
             (Event::End(TagEnd::CodeBlock), true) => {
@@ -106,19 +130,19 @@ fn process_events<'a>(
                     chapter.number.as_ref(),
                     diagram_index,
                 );
-                backend
-                    .render(&render_context, &diagram)
-                    .unwrap_or_else(|e| {
-                        // if we cannot render the diagram, print the error and return an empty
-                        // block
-                        eprintln!("{e}");
-                        vec![]
-                    })
+                match backend.render(&render_context, &diagram) {
+                    Ok(rendered) => out.extend(rendered),
+                    // if we cannot render the diagram, record the error and omit
+                    // the block; the caller surfaces it and fails the build
+                    Err(e) => errors.push(e),
+                }
             }
             // if nothing matches, change nothing
-            _ => vec![event],
+            _ => out.push(event),
         }
-    })
+    }
+
+    out
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,15 +46,23 @@ impl Preprocessor for D2 {
         });
 
         if !errors.is_empty() {
-            let details = errors
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join("\n");
-            return Err(anyhow::anyhow!(
-                "failed to render {} d2 diagram(s):\n{details}",
-                errors.len()
-            ));
+            if backend.fail_on_error() {
+                let details = errors
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(anyhow::anyhow!(
+                    "failed to render {} d2 diagram(s):\n{details}",
+                    errors.len()
+                ));
+            }
+
+            // Otherwise report the failures but let the build succeed, omitting
+            // the offending diagrams.
+            for e in &errors {
+                eprintln!("{e}");
+            }
         }
 
         Ok(book)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,15 @@ impl Preprocessor for D2 {
     fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book, Error> {
         let backend = Backend::from_context(ctx);
 
-        // Collect every diagram that fails to render rather than bailing on the
-        // first one, so a single build reports all broken diagrams at once.
+        // Collect every render failure rather than bailing on the first, so a
+        // single build reports all broken diagrams at once.
         let mut errors: Vec<Error> = Vec::new();
 
         book.for_each_mut(|section| {
             if let BookItem::Chapter(chapter) = section {
-                chapter.content = render_chapter(&backend, chapter, &mut errors);
+                let (content, chapter_errors) = render_chapter(&backend, chapter);
+                chapter.content = content;
+                errors.extend(chapter_errors);
             }
         });
 
@@ -59,16 +61,16 @@ impl Preprocessor for D2 {
     }
 }
 
-/// Renders all d2 diagrams in a chapter and returns the rewritten markdown.
+/// Renders all d2 diagrams in a chapter, returning the rewritten markdown
+/// alongside any diagrams that failed to render.
 ///
-/// Any diagram that fails to render is pushed onto `errors` (and omitted from
-/// the output) so the caller can surface every failure and fail the build.
-fn render_chapter(backend: &Backend, chapter: &Chapter, errors: &mut Vec<Error>) -> String {
-    let events = process_events(
+/// Diagrams that fail to render are omitted from the output; the caller
+/// surfaces the returned errors to fail the build.
+fn render_chapter(backend: &Backend, chapter: &Chapter) -> (String, Vec<Error>) {
+    let (events, errors) = process_events(
         backend,
         chapter,
         Parser::new_ext(&chapter.content, Options::all()),
-        errors,
     );
 
     // Determine the minimum number of backticks needed for code blocks.
@@ -89,26 +91,29 @@ fn render_chapter(backend: &Backend, chapter: &Chapter, errors: &mut Vec<Error>)
     // convert it back to markdown
     cmark_with_options(events.into_iter(), &mut buf, options).unwrap();
 
-    buf
+    (buf, errors)
 }
 
+/// Replaces each d2 code block in the event stream with its rendered output,
+/// partitioning the results into the rewritten events and any render errors.
 fn process_events<'a>(
     backend: &Backend,
     chapter: &Chapter,
     events: impl Iterator<Item = Event<'a>>,
-    errors: &mut Vec<Error>,
-) -> Vec<Event<'a>> {
+) -> (Vec<Event<'a>>, Vec<Error>) {
     let mut in_block = false;
     // if Windows crlf line endings are used, a code block will consist
     // of many different Text blocks, thus we need to buffer them in here
     // see https://github.com/raphlinus/pulldown-cmark/issues/507
     let mut diagram = String::new();
     let mut diagram_index = 0;
-    let mut out = Vec::new();
 
-    for event in events {
-        match (&event, in_block) {
-            // check if we are entering a d2 codeblock
+    // Map each input event to the output events it produces. Most events pass
+    // through unchanged; entering/inside a d2 block produces nothing; closing a
+    // d2 block produces the rendered diagram, or a render error.
+    events
+        .filter_map(|event| match (&event, in_block) {
+            // entering a d2 codeblock
             (
                 Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(CowStr::Borrowed("d2")))),
                 false,
@@ -116,12 +121,14 @@ fn process_events<'a>(
                 in_block = true;
                 diagram.clear();
                 diagram_index += 1;
+                None
             }
-            // check if we are currently inside a d2 block
+            // inside a d2 block
             (Event::Text(content), true) => {
                 diagram.push_str(content);
+                None
             }
-            // check if we are exiting a d2 block
+            // exiting a d2 block
             (Event::End(TagEnd::CodeBlock), true) => {
                 in_block = false;
                 let render_context = RenderContext::new(
@@ -130,19 +137,23 @@ fn process_events<'a>(
                     chapter.number.as_ref(),
                     diagram_index,
                 );
-                match backend.render(&render_context, &diagram) {
-                    Ok(rendered) => out.extend(rendered),
-                    // if we cannot render the diagram, record the error and omit
-                    // the block; the caller surfaces it and fails the build
+                Some(backend.render(&render_context, &diagram))
+            }
+            // anything else passes through unchanged
+            _ => Some(Ok(vec![event])),
+        })
+        // separate successfully-rendered events from render errors, flattening
+        // each successful chunk back into the output stream
+        .fold(
+            (Vec::new(), Vec::new()),
+            |(mut events, mut errors), result| {
+                match result {
+                    Ok(rendered) => events.extend(rendered),
                     Err(e) => errors.push(e),
                 }
-            }
-            // if nothing matches, change nothing
-            _ => out.push(event),
-        }
-    }
-
-    out
+                (events, errors)
+            },
+        )
 }
 
 #[cfg(test)]

--- a/tests/library/broken-default/book.toml
+++ b/tests/library/broken-default/book.toml
@@ -6,6 +6,5 @@ inline = true
 layout = "elk"
 theme-id = "101"
 dark-theme-id = "200"
-fail-on-error = true
 
 [output.html]

--- a/tests/library/broken-default/src/SUMMARY.md
+++ b/tests/library/broken-default/src/SUMMARY.md
@@ -1,0 +1,4 @@
+
+# Summary
+
+- [Chapter 1](./chapter1.md)

--- a/tests/library/broken-default/src/chapter1.md
+++ b/tests/library/broken-default/src/chapter1.md
@@ -1,0 +1,7 @@
+# Chapter 1
+
+This chapter contains an invalid D2 diagram that fails to compile:
+
+```d2
+x: {
+```

--- a/tests/library/broken/book.toml
+++ b/tests/library/broken/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "Test Book"
+
+[preprocessor.d2]
+inline = true
+layout = "elk"
+theme-id = "101"
+dark-theme-id = "200"
+
+[output.html]

--- a/tests/library/broken/src/SUMMARY.md
+++ b/tests/library/broken/src/SUMMARY.md
@@ -1,0 +1,4 @@
+
+# Summary
+
+- [Chapter 1](./chapter1.md)

--- a/tests/library/broken/src/chapter1.md
+++ b/tests/library/broken/src/chapter1.md
@@ -1,0 +1,7 @@
+# Chapter 1
+
+This chapter contains an invalid D2 diagram that fails to compile:
+
+```d2
+x: {
+```

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -40,11 +40,21 @@ fn custom_src() {
 }
 
 #[test]
-fn broken_diagram_fails_build() {
+fn broken_diagram_fails_build_when_fail_on_error() {
     let result = TestBook::new("broken");
 
     assert!(
         result.is_err(),
-        "build should fail when a d2 diagram is invalid"
+        "build should fail when a d2 diagram is invalid and fail-on-error is set"
+    );
+}
+
+#[test]
+fn broken_diagram_succeeds_by_default() {
+    let result = TestBook::new("broken-default");
+
+    assert!(
+        result.is_ok(),
+        "build should succeed when a d2 diagram is invalid and fail-on-error is unset"
     );
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -38,3 +38,13 @@ fn custom_src() {
     assert!(output.exists());
     assert!(test_book.chapter1_contains(r#"img src="d2/1.1.svg" alt="">"#));
 }
+
+#[test]
+fn broken_diagram_fails_build() {
+    let result = TestBook::new("broken");
+
+    assert!(
+        result.is_err(),
+        "build should fail when a d2 diagram is invalid"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #190.

Previously, when a d2 diagram failed to render, `mdbook-d2` printed the error to stderr but still returned success. As a result, `mdbook build`/`serve` exited `0` and broken diagrams went unnoticed — including in CI, which reported green even though the d2 preprocessor had failed.

The root cause was the `unwrap_or_else` in `process_events`, which swallowed the render error (printing it and substituting an empty block) instead of propagating it. Because `process_events` was an error-swallowing iterator, the error never reached `run` (which already returns `Result<Book, Error>`).

## Behaviour

The build-failure behaviour is **opt-in** via a new config key, so this is **not** a breaking change — the default preserves the historical print-and-continue behaviour:

```toml
[preprocessor.d2]
# whether a diagram that fails to render should fail the whole build.
# if 'false', render failures are printed to stderr and the offending diagram is
# omitted, but the build still succeeds.
# optional. default is 'false'
fail-on-error = false
```

- **`fail-on-error = false`** (default): render failures are printed to stderr and the offending diagram is omitted, but the build still succeeds (exit `0`).
- **`fail-on-error = true`**: any render failure fails the build (non-zero exit), reporting **every** broken diagram in a single run rather than aborting on the first.

## Changes

- `process_events` is now a pure function: it maps the event stream to `Result<Vec<Event>, Error>` chunks and partitions them into the rewritten events and any render errors (no error-swallowing, no out-parameter).
- `run` accumulates render errors across all chapters and, based on `fail-on-error`, either returns an `Err` listing all failures or prints them and continues.
- Added the `fail-on-error` config key (`src/config.rs`), plumbed through `Backend` (`src/backend.rs`), and documented it in the README.

The error message includes the chapter name, diagram index, and the underlying `d2` stderr:

```
failed to render 1 d2 diagram(s):
failed to compile D2 diagram (Chapter 1, #1):
  err: failed to compile -: -:1:4: maps must be terminated with }
```

## Testing

- `broken` fixture (invalid d2 + `fail-on-error = true`) with `broken_diagram_fails_build_when_fail_on_error` asserting the build fails.
- `broken-default` fixture (invalid d2, default config) with `broken_diagram_succeeds_by_default` asserting the build still succeeds.
- Config parsing test for `fail-on-error = true`.
- `cargo test`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all pass.
- Manually verified end-to-end: default config exits `0` (warns), `fail-on-error = true` exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
